### PR TITLE
Generate typed helpers

### DIFF
--- a/mockery/generator.go
+++ b/mockery/generator.go
@@ -49,6 +49,12 @@ func (g *Generator) GenerateIPPrologue() {
 	g.printf("\n")
 }
 
+func (g *Generator) generateMockOn(variant string, fname string, builderParams []string, onParams []string) {
+	g.printf("func (m *%s) MockOn%s_%s(%s) *mock.Mock {\n", g.mockName(), variant, fname, strings.Join(builderParams, ", "))
+	g.printf("\treturn m.Mock.On(%s)\n", strings.Join(append([]string{"\"" + fname + "\""}, onParams...), ", "))
+	g.printf("}\n")
+}
+
 func (g *Generator) mockName() string {
 	if g.ip {
 		if ast.IsExported(g.iface.Name) {
@@ -280,6 +286,16 @@ func (g *Generator) Generate() error {
 
 		paramNames, paramTypes, params := g.genList(ftype.Params, true)
 		_, returnTypes, returns := g.genList(ftype.Results, false)
+
+		paramsInterface := []string{}
+		paramsAnything := []string{}
+		for _, p := range paramNames {
+			paramsInterface = append(paramsInterface, p+" interface{}")
+			paramsAnything = append(paramsAnything, "mock.Anything")
+		}
+		g.generateMockOn("", fname, paramsInterface, paramNames)
+		g.generateMockOn("Typed", fname, params, paramNames)
+		g.generateMockOn("Any", fname, []string{}, paramsAnything)
 
 		g.printf("func (m *%s) %s(%s) ", g.mockName(), fname, strings.Join(params, ", "))
 

--- a/mockery/generator.go
+++ b/mockery/generator.go
@@ -287,6 +287,10 @@ func (g *Generator) Generate() error {
 		paramNames, paramTypes, params := g.genList(ftype.Params, true)
 		_, returnTypes, returns := g.genList(ftype.Results, false)
 
+		g.printf("func (m *%s) Name_%s() string {\n", g.mockName(), fname)
+		g.printf("\treturn %s\n", "\""+fname+"\"")
+		g.printf("}\n")
+
 		paramsInterface := []string{}
 		paramsAnything := []string{}
 		for _, p := range paramNames {

--- a/mockery/generator_test.go
+++ b/mockery/generator_test.go
@@ -22,6 +22,9 @@ func TestGenerator(t *testing.T) {
 	mock.Mock
 }
 
+func (m *Requester) Name_Get() string {
+	return "Get"
+}
 func (m *Requester) MockOn_Get(path interface{}) *mock.Mock {
 	return m.Mock.On("Get", path)
 }
@@ -70,6 +73,9 @@ func TestGeneratorSingleReturn(t *testing.T) {
 	mock.Mock
 }
 
+func (m *Requester2) Name_Get() string {
+	return "Get"
+}
 func (m *Requester2) MockOn_Get(path interface{}) *mock.Mock {
 	return m.Mock.On("Get", path)
 }
@@ -111,6 +117,9 @@ func TestGeneratorNoArguments(t *testing.T) {
 	mock.Mock
 }
 
+func (m *Requester3) Name_Get() string {
+	return "Get"
+}
 func (m *Requester3) MockOn_Get() *mock.Mock {
 	return m.Mock.On("Get")
 }
@@ -152,6 +161,9 @@ func TestGeneratorNoNothing(t *testing.T) {
 	mock.Mock
 }
 
+func (m *Requester4) Name_Get() string {
+	return "Get"
+}
 func (m *Requester4) MockOn_Get() *mock.Mock {
 	return m.Mock.On("Get")
 }
@@ -185,6 +197,9 @@ func TestGeneratorUnexported(t *testing.T) {
 	mock.Mock
 }
 
+func (m *mockRequester) Name_Get() string {
+	return "Get"
+}
 func (m *mockRequester) MockOn_Get() *mock.Mock {
 	return m.Mock.On("Get")
 }
@@ -263,6 +278,9 @@ func TestGeneratorPointers(t *testing.T) {
 	mock.Mock
 }
 
+func (m *RequesterPtr) Name_Get() string {
+	return "Get"
+}
 func (m *RequesterPtr) MockOn_Get(path interface{}) *mock.Mock {
 	return m.Mock.On("Get", path)
 }
@@ -315,6 +333,9 @@ func TestGeneratorSlice(t *testing.T) {
 	mock.Mock
 }
 
+func (m *RequesterSlice) Name_Get() string {
+	return "Get"
+}
 func (m *RequesterSlice) MockOn_Get(path interface{}) *mock.Mock {
 	return m.Mock.On("Get", path)
 }
@@ -367,6 +388,9 @@ func TestGeneratorArrayLiteralLen(t *testing.T) {
 	mock.Mock
 }
 
+func (m *RequesterArray) Name_Get() string {
+	return "Get"
+}
 func (m *RequesterArray) MockOn_Get(path interface{}) *mock.Mock {
 	return m.Mock.On("Get", path)
 }
@@ -419,6 +443,9 @@ func TestGeneratorNamespacedTypes(t *testing.T) {
 	mock.Mock
 }
 
+func (m *RequesterNS) Name_Get() string {
+	return "Get"
+}
 func (m *RequesterNS) MockOn_Get(path interface{}) *mock.Mock {
 	return m.Mock.On("Get", path)
 }
@@ -470,6 +497,9 @@ func TestGeneratorHavingNoNamesOnArguments(t *testing.T) {
 	mock.Mock
 }
 
+func (m *KeyManager) Name_GetKey() string {
+	return "GetKey"
+}
 func (m *KeyManager) MockOn_GetKey(_a0 interface{}, _a1 interface{}) *mock.Mock {
 	return m.Mock.On("GetKey", _a0, _a1)
 }
@@ -522,6 +552,9 @@ func TestGeneratorElidedType(t *testing.T) {
 	mock.Mock
 }
 
+func (m *RequesterElided) Name_Get() string {
+	return "Get"
+}
 func (m *RequesterElided) MockOn_Get(path interface{}, url interface{}) *mock.Mock {
 	return m.Mock.On("Get", path, url)
 }
@@ -563,6 +596,9 @@ func TestGeneratorFuncType(t *testing.T) {
 	mock.Mock
 }
 
+func (m *Fooer) Name_Foo() string {
+	return "Foo"
+}
 func (m *Fooer) MockOn_Foo(f interface{}) *mock.Mock {
 	return m.Mock.On("Foo", f)
 }
@@ -584,6 +620,9 @@ func (m *Fooer) Foo(f func(string) string) error {
 
 	return r0
 }
+func (m *Fooer) Name_Bar() string {
+	return "Bar"
+}
 func (m *Fooer) MockOn_Bar(f interface{}) *mock.Mock {
 	return m.Mock.On("Bar", f)
 }
@@ -595,6 +634,9 @@ func (m *Fooer) MockOnAny_Bar() *mock.Mock {
 }
 func (m *Fooer) Bar(f func([]int) ) {
 	m.Called(f)
+}
+func (m *Fooer) Name_Baz() string {
+	return "Baz"
 }
 func (m *Fooer) MockOn_Baz(path interface{}) *mock.Mock {
 	return m.Mock.On("Baz", path)
@@ -639,6 +681,9 @@ func TestGeneratorChanType(t *testing.T) {
 	mock.Mock
 }
 
+func (m *AsyncProducer) Name_Input() string {
+	return "Input"
+}
 func (m *AsyncProducer) MockOn_Input() *mock.Mock {
 	return m.Mock.On("Input")
 }
@@ -662,6 +707,9 @@ func (m *AsyncProducer) Input() chan<- bool {
 
 	return r0
 }
+func (m *AsyncProducer) Name_Output() string {
+	return "Output"
+}
 func (m *AsyncProducer) MockOn_Output() *mock.Mock {
 	return m.Mock.On("Output")
 }
@@ -684,6 +732,9 @@ func (m *AsyncProducer) Output() <-chan bool {
 	}
 
 	return r0
+}
+func (m *AsyncProducer) Name_Whatever() string {
+	return "Whatever"
 }
 func (m *AsyncProducer) MockOn_Whatever() *mock.Mock {
 	return m.Mock.On("Whatever")

--- a/mockery/generator_test.go
+++ b/mockery/generator_test.go
@@ -22,6 +22,15 @@ func TestGenerator(t *testing.T) {
 	mock.Mock
 }
 
+func (m *Requester) MockOn_Get(path interface{}) *mock.Mock {
+	return m.Mock.On("Get", path)
+}
+func (m *Requester) MockOnTyped_Get(path string) *mock.Mock {
+	return m.Mock.On("Get", path)
+}
+func (m *Requester) MockOnAny_Get() *mock.Mock {
+	return m.Mock.On("Get", mock.Anything)
+}
 func (m *Requester) Get(path string) (string, error) {
 	ret := m.Called(path)
 
@@ -61,6 +70,15 @@ func TestGeneratorSingleReturn(t *testing.T) {
 	mock.Mock
 }
 
+func (m *Requester2) MockOn_Get(path interface{}) *mock.Mock {
+	return m.Mock.On("Get", path)
+}
+func (m *Requester2) MockOnTyped_Get(path string) *mock.Mock {
+	return m.Mock.On("Get", path)
+}
+func (m *Requester2) MockOnAny_Get() *mock.Mock {
+	return m.Mock.On("Get", mock.Anything)
+}
 func (m *Requester2) Get(path string) error {
 	ret := m.Called(path)
 
@@ -93,6 +111,15 @@ func TestGeneratorNoArguments(t *testing.T) {
 	mock.Mock
 }
 
+func (m *Requester3) MockOn_Get() *mock.Mock {
+	return m.Mock.On("Get")
+}
+func (m *Requester3) MockOnTyped_Get() *mock.Mock {
+	return m.Mock.On("Get")
+}
+func (m *Requester3) MockOnAny_Get() *mock.Mock {
+	return m.Mock.On("Get")
+}
 func (m *Requester3) Get() error {
 	ret := m.Called()
 
@@ -125,6 +152,15 @@ func TestGeneratorNoNothing(t *testing.T) {
 	mock.Mock
 }
 
+func (m *Requester4) MockOn_Get() *mock.Mock {
+	return m.Mock.On("Get")
+}
+func (m *Requester4) MockOnTyped_Get() *mock.Mock {
+	return m.Mock.On("Get")
+}
+func (m *Requester4) MockOnAny_Get() *mock.Mock {
+	return m.Mock.On("Get")
+}
 func (m *Requester4) Get() {
 	m.Called()
 }
@@ -149,6 +185,15 @@ func TestGeneratorUnexported(t *testing.T) {
 	mock.Mock
 }
 
+func (m *mockRequester) MockOn_Get() *mock.Mock {
+	return m.Mock.On("Get")
+}
+func (m *mockRequester) MockOnTyped_Get() *mock.Mock {
+	return m.Mock.On("Get")
+}
+func (m *mockRequester) MockOnAny_Get() *mock.Mock {
+	return m.Mock.On("Get")
+}
 func (m *mockRequester) Get() {
 	m.Called()
 }
@@ -218,6 +263,15 @@ func TestGeneratorPointers(t *testing.T) {
 	mock.Mock
 }
 
+func (m *RequesterPtr) MockOn_Get(path interface{}) *mock.Mock {
+	return m.Mock.On("Get", path)
+}
+func (m *RequesterPtr) MockOnTyped_Get(path string) *mock.Mock {
+	return m.Mock.On("Get", path)
+}
+func (m *RequesterPtr) MockOnAny_Get() *mock.Mock {
+	return m.Mock.On("Get", mock.Anything)
+}
 func (m *RequesterPtr) Get(path string) (*string, error) {
 	ret := m.Called(path)
 
@@ -261,6 +315,15 @@ func TestGeneratorSlice(t *testing.T) {
 	mock.Mock
 }
 
+func (m *RequesterSlice) MockOn_Get(path interface{}) *mock.Mock {
+	return m.Mock.On("Get", path)
+}
+func (m *RequesterSlice) MockOnTyped_Get(path string) *mock.Mock {
+	return m.Mock.On("Get", path)
+}
+func (m *RequesterSlice) MockOnAny_Get() *mock.Mock {
+	return m.Mock.On("Get", mock.Anything)
+}
 func (m *RequesterSlice) Get(path string) ([]string, error) {
 	ret := m.Called(path)
 
@@ -304,6 +367,15 @@ func TestGeneratorArrayLiteralLen(t *testing.T) {
 	mock.Mock
 }
 
+func (m *RequesterArray) MockOn_Get(path interface{}) *mock.Mock {
+	return m.Mock.On("Get", path)
+}
+func (m *RequesterArray) MockOnTyped_Get(path string) *mock.Mock {
+	return m.Mock.On("Get", path)
+}
+func (m *RequesterArray) MockOnAny_Get() *mock.Mock {
+	return m.Mock.On("Get", mock.Anything)
+}
 func (m *RequesterArray) Get(path string) ([2]string, error) {
 	ret := m.Called(path)
 
@@ -347,6 +419,15 @@ func TestGeneratorNamespacedTypes(t *testing.T) {
 	mock.Mock
 }
 
+func (m *RequesterNS) MockOn_Get(path interface{}) *mock.Mock {
+	return m.Mock.On("Get", path)
+}
+func (m *RequesterNS) MockOnTyped_Get(path string) *mock.Mock {
+	return m.Mock.On("Get", path)
+}
+func (m *RequesterNS) MockOnAny_Get() *mock.Mock {
+	return m.Mock.On("Get", mock.Anything)
+}
 func (m *RequesterNS) Get(path string) (http.Response, error) {
 	ret := m.Called(path)
 
@@ -389,6 +470,15 @@ func TestGeneratorHavingNoNamesOnArguments(t *testing.T) {
 	mock.Mock
 }
 
+func (m *KeyManager) MockOn_GetKey(_a0 interface{}, _a1 interface{}) *mock.Mock {
+	return m.Mock.On("GetKey", _a0, _a1)
+}
+func (m *KeyManager) MockOnTyped_GetKey(_a0 string, _a1 uint16) *mock.Mock {
+	return m.Mock.On("GetKey", _a0, _a1)
+}
+func (m *KeyManager) MockOnAny_GetKey() *mock.Mock {
+	return m.Mock.On("GetKey", mock.Anything, mock.Anything)
+}
 func (m *KeyManager) GetKey(_a0 string, _a1 uint16) ([]byte, *test.Err) {
 	ret := m.Called(_a0, _a1)
 
@@ -432,6 +522,15 @@ func TestGeneratorElidedType(t *testing.T) {
 	mock.Mock
 }
 
+func (m *RequesterElided) MockOn_Get(path interface{}, url interface{}) *mock.Mock {
+	return m.Mock.On("Get", path, url)
+}
+func (m *RequesterElided) MockOnTyped_Get(path string, url string) *mock.Mock {
+	return m.Mock.On("Get", path, url)
+}
+func (m *RequesterElided) MockOnAny_Get() *mock.Mock {
+	return m.Mock.On("Get", mock.Anything, mock.Anything)
+}
 func (m *RequesterElided) Get(path string, url string) error {
 	ret := m.Called(path, url)
 
@@ -464,6 +563,15 @@ func TestGeneratorFuncType(t *testing.T) {
 	mock.Mock
 }
 
+func (m *Fooer) MockOn_Foo(f interface{}) *mock.Mock {
+	return m.Mock.On("Foo", f)
+}
+func (m *Fooer) MockOnTyped_Foo(f func(string) string) *mock.Mock {
+	return m.Mock.On("Foo", f)
+}
+func (m *Fooer) MockOnAny_Foo() *mock.Mock {
+	return m.Mock.On("Foo", mock.Anything)
+}
 func (m *Fooer) Foo(f func(string) string) error {
 	ret := m.Called(f)
 
@@ -476,8 +584,26 @@ func (m *Fooer) Foo(f func(string) string) error {
 
 	return r0
 }
+func (m *Fooer) MockOn_Bar(f interface{}) *mock.Mock {
+	return m.Mock.On("Bar", f)
+}
+func (m *Fooer) MockOnTyped_Bar(f func([]int) ) *mock.Mock {
+	return m.Mock.On("Bar", f)
+}
+func (m *Fooer) MockOnAny_Bar() *mock.Mock {
+	return m.Mock.On("Bar", mock.Anything)
+}
 func (m *Fooer) Bar(f func([]int) ) {
 	m.Called(f)
+}
+func (m *Fooer) MockOn_Baz(path interface{}) *mock.Mock {
+	return m.Mock.On("Baz", path)
+}
+func (m *Fooer) MockOnTyped_Baz(path string) *mock.Mock {
+	return m.Mock.On("Baz", path)
+}
+func (m *Fooer) MockOnAny_Baz() *mock.Mock {
+	return m.Mock.On("Baz", mock.Anything)
 }
 func (m *Fooer) Baz(path string) func(string) string {
 	ret := m.Called(path)
@@ -513,6 +639,15 @@ func TestGeneratorChanType(t *testing.T) {
 	mock.Mock
 }
 
+func (m *AsyncProducer) MockOn_Input() *mock.Mock {
+	return m.Mock.On("Input")
+}
+func (m *AsyncProducer) MockOnTyped_Input() *mock.Mock {
+	return m.Mock.On("Input")
+}
+func (m *AsyncProducer) MockOnAny_Input() *mock.Mock {
+	return m.Mock.On("Input")
+}
 func (m *AsyncProducer) Input() chan<- bool {
 	ret := m.Called()
 
@@ -527,6 +662,15 @@ func (m *AsyncProducer) Input() chan<- bool {
 
 	return r0
 }
+func (m *AsyncProducer) MockOn_Output() *mock.Mock {
+	return m.Mock.On("Output")
+}
+func (m *AsyncProducer) MockOnTyped_Output() *mock.Mock {
+	return m.Mock.On("Output")
+}
+func (m *AsyncProducer) MockOnAny_Output() *mock.Mock {
+	return m.Mock.On("Output")
+}
 func (m *AsyncProducer) Output() <-chan bool {
 	ret := m.Called()
 
@@ -540,6 +684,15 @@ func (m *AsyncProducer) Output() <-chan bool {
 	}
 
 	return r0
+}
+func (m *AsyncProducer) MockOn_Whatever() *mock.Mock {
+	return m.Mock.On("Whatever")
+}
+func (m *AsyncProducer) MockOnTyped_Whatever() *mock.Mock {
+	return m.Mock.On("Whatever")
+}
+func (m *AsyncProducer) MockOnAny_Whatever() *mock.Mock {
+	return m.Mock.On("Whatever")
 }
 func (m *AsyncProducer) Whatever() chan bool {
 	ret := m.Called()


### PR DESCRIPTION
To avoid writing the `methodName` param in `testify/mock` as a `string`, this adds generated helper method:
- `MockOn_*`: takes `interface{}` as params and returns a mock for the method
- `MockOnTyped_*`: takes typed params and returns a mock for the method
- `MockOnAny_*`: returns a mock for the method with `mock.Anything` for all params
- `Name_*`: returns the method name itself (used for other methods that need `methodName` besides `Mock.On`)

Examples of expansion:

```
activities.MockOn_Foo(1, 2):
activities.Mock.On("Foo", 1, 2)

activities.MockOnTyped_Foo(1, 2):
activities.Mock.On("Foo", 1, 2))

activities.MockOnAny_Foo(): 
activities.Mock.On("Foo", mock.Anything, mock.Anything)
```

I believe this is preferable to obtaining the method name by reflection because its less repetitive, results in shorter mocks, can be typed, and avoids common pattern of `mock.Anything` for all params. It of course does require code gen, but if using mockery, projects would be doing this anyway.

/cc @sclasen
